### PR TITLE
case insentivity when matching strat, and fix register unit test

### DIFF
--- a/pkg/pins/models/textmatch.go
+++ b/pkg/pins/models/textmatch.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 )
 
 const (
@@ -29,7 +30,7 @@ func (tm TextMatch) String() (match string) {
 
 func ToTextMatch(m string) (TextMatch, error) {
 	for i, tm := range TextMatchStrings {
-		if tm == m {
+		if strings.EqualFold(tm, m) {
 			return TextMatch(i), nil
 		}
 	}

--- a/pkg/pins/models/textmatch_test.go
+++ b/pkg/pins/models/textmatch_test.go
@@ -14,7 +14,7 @@ func TestMatchString(t *testing.T) {
 
 func TestToTextMatch(t *testing.T) {
 	expected := TextMatchIExact
-	actual, err := ToTextMatch("iexact")
+	actual, err := ToTextMatch("iExact")
 	require.Nil(t, err)
 	require.Equal(t, expected, actual)
 }


### PR DESCRIPTION
- Strings are no longer sensitive when converting to `TextMatch`
- Fix run condition in `TestPinWatcherRegister` unit test