### PR TITLE
Upgrade to bullseye

### DIFF
--- a/deployments/docker/pins.Dockerfile
+++ b/deployments/docker/pins.Dockerfile
@@ -1,5 +1,5 @@
 ARG OS=debian:bullseye-slim
-ARG GOLANG_VERSION=1.17-bullseye
+ARG GOLANG_VERSION=1.19-bullseye
 ARG CGO=0
 ARG GOOS=linux
 ARG GOARCH=amd64

--- a/pkg/pinwatcher/statustracker.go
+++ b/pkg/pinwatcher/statustracker.go
@@ -26,7 +26,8 @@ type statusTracker struct {
 	client cluster.Client
 	pin    models.PinStatus
 	db     pinsdb.Pins
-	quit   chan struct{}
+	// TODO we should be closing this channel when quiting
+	quit chan struct{}
 }
 
 func NewStatusTracker(


### PR DESCRIPTION
### Description
Ticket: GslmL-2022911
- Upgrade to `go1.19` on Debian `bullseye` in Dockerfile(s)